### PR TITLE
spec file: Add "Conflicts:" to sailfishos-chum-gui

### DIFF
--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -8,6 +8,7 @@ Group:          System
 Source0:        %{name}-%{version}.tar.bz2
 Requires:       ssu
 Conflicts:      sailfishos-chum-testing
+Conflicts:      sailfishos-chum-gui
 BuildArch:      noarch
 
 %description
@@ -20,6 +21,7 @@ Provides:       sailfishos-chum-repository
 Group:          System
 Requires:       ssu
 Conflicts:      sailfishos-chum
+Conflicts:      sailfishos-chum-gui
 BuildArch:      noarch
 
 %description testing


### PR DESCRIPTION
… in order to prevent any of the three packages {`sailfishos-chum`|`sailfishos-chum-testing`|`sailfishos-chum-gui`} to be installed concurrently.
After [SailfishOS:Chum GUI application commit `1cce90a`](https://github.com/sailfishos-chum/sailfishos-chum-gui/pull/115/commits/1cce90a55f4a51ac5395b6fa8d8c2cdbcce34778) all three RPMs also `Provides: sailfishos-chum-repository`, so this can be used to check if any SailfishOS:Chum repository (either the regular or the testing one) is configured on a device.