### PR TITLE
spec file: Bump version to 0.4.2 …

### DIFF
--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -1,7 +1,7 @@
 Summary:        SSU configuration for the SailfishOS:Chum community repository
 License:        MIT
 Name:           sailfishos-chum
-Version:        0.3.0
+Version:        0.4.2
 Release:        1
 Provides:       sailfishos-chum-repository
 Group:          System


### PR DESCRIPTION
because git-tag, its name and the version in the spec file [deviated since 0.3.0](https://github.com/sailfishos-chum/main/releases).