### PR TITLE
Cleanup: Delete ssu directory

### DIFF
--- a/ssu/sailfishos-chum-testing.ini
+++ b/ssu/sailfishos-chum-testing.ini
@@ -1,7 +1,0 @@
-[sailfishos-chum-testing]
-repos = sailfishos-chum-testing
-pattern = SailfishOS:Chum community repository: Testing repository
-description = SailfishOS:Chum community packages: Testing repository
-
-[repositories-release]
-sailfishos-chum-testing = https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/%(release)_%(arch)/

--- a/ssu/sailfishos-chum.ini
+++ b/ssu/sailfishos-chum.ini
@@ -1,7 +1,0 @@
-[sailfishos-chum]
-repos = sailfishos-chum
-pattern = SailfishOS:Chum community repository
-description = SailfishOS:Chum community packages
-
-[repositories-release]
-sailfishos-chum = https://repo.sailfishos.org/obs/sailfishos:/chum/%(release)_%(arch)/


### PR DESCRIPTION
… because the two files it contains are not used any more (see https://github.com/sailfishos-chum/main/blob/main/rpm/chum.spec), as these `.ini` files should not be used for adding these two repositories to the global entries of `ssu.ini`, which was their purpose.