### PR TITLE
Overhaul spec file

### DIFF
--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -6,7 +6,7 @@ Release:        1
 Provides:       sailfishos-chum-repository
 Group:          System
 Source0:        %{name}-%{version}.tar.bz2
-Requires(post): ssu
+Requires(post,postun): ssu
 Requires:       ssu
 Conflicts:      sailfishos-chum-testing
 Conflicts:      sailfishos-chum-gui
@@ -61,7 +61,7 @@ sailfishos-chum-testing RPM.
 %files testing
 
 %post
-if echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum
+if ! echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum
 then
   ssu ar sailfishos-chum 'https://repo.sailfishos.org/obs/sailfishos:/chum/%%(release)_%%(arch)/'
   ssu ur
@@ -69,7 +69,7 @@ fi
 exit 0
 
 %post testing
-if echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum-testing
+if ! echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum-testing
 then
   ssu ar sailfishos-chum-testing 'https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/%%(release)_%%(arch)/'
   ssu ur

--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -7,7 +7,8 @@ Provides:       sailfishos-chum-repository
 Group:          System
 Source0:        %{name}-%{version}.tar.bz2
 Requires:       ssu
-Requires(post,postun): ssu
+Requires(post): ssu
+Requires(postun): ssu
 Conflicts:      sailfishos-chum-testing
 Conflicts:      sailfishos-chum-gui
 BuildArch:      noarch
@@ -30,7 +31,8 @@ License:        MIT
 Provides:       sailfishos-chum-repository
 Group:          System
 Requires:       ssu
-Requires(post,postun): ssu
+Requires(post): ssu
+Requires(postun): ssu
 Conflicts:      sailfishos-chum
 Conflicts:      sailfishos-chum-gui
 BuildArch:      noarch

--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -61,7 +61,7 @@ sailfishos-chum-testing RPM.
 %files testing
 
 %post
-if ! echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum
+if ! ssu lr | grep '^ - ' | cut -f 3 -d ' ' | grep -Fq sailfishos-chum
 then
   ssu ar sailfishos-chum 'https://repo.sailfishos.org/obs/sailfishos:/chum/%%(release)_%%(arch)/'
   ssu ur
@@ -69,7 +69,7 @@ fi
 exit 0
 
 %post testing
-if ! echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum-testing
+if ! ssu lr | grep '^ - ' | cut -f 3 -d ' ' | grep -Fq sailfishos-chum-testing
 then
   ssu ar sailfishos-chum-testing 'https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/%%(release)_%%(arch)/'
   ssu ur

--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -6,8 +6,8 @@ Release:        1
 Provides:       sailfishos-chum-repository
 Group:          System
 Source0:        %{name}-%{version}.tar.bz2
-Requires(post,postun): ssu
 Requires:       ssu
+Requires(post,postun): ssu
 Conflicts:      sailfishos-chum-testing
 Conflicts:      sailfishos-chum-gui
 BuildArch:      noarch
@@ -29,8 +29,8 @@ Summary:        SSU configuration for the SailfishOS:Chum TESTING repository
 License:        MIT
 Provides:       sailfishos-chum-repository
 Group:          System
-Requires(post): ssu
 Requires:       ssu
+Requires(post,postun): ssu
 Conflicts:      sailfishos-chum
 Conflicts:      sailfishos-chum-gui
 BuildArch:      noarch

--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -48,7 +48,7 @@ Hence you might rather install the sailfishos-chum-gui RPM instead of the
 sailfishos-chum-testing RPM.
 
 %prep
-%setup -q -n %{name}-%{version}
+%setup -q
 
 %build
 
@@ -59,35 +59,43 @@ sailfishos-chum-testing RPM.
 %files testing
 
 %post
-if printf %s "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum
+if echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum
 then
   ssu ar sailfishos-chum 'https://repo.sailfishos.org/obs/sailfishos:/chum/%%(release)_%%(arch)/'
   ssu ur
 fi
+exit 0
 
 %post testing
-if printf %s "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum-testing
+if echo "$(ssu lr | grep '^ - ' | cut -f 3 -d ' ')" | grep -Fq sailfishos-chum-testing
 then
   ssu ar sailfishos-chum-testing 'https://repo.sailfishos.org/obs/sailfishos:/chum:/testing/%%(release)_%%(arch)/'
   ssu ur
 fi
+exit 0
 
 %postun
-if [ $1 = 0 ]  # Removal
+if [ "$1" = 0 ]  # Removal
   ssu rr sailfishos-chum
   rm -f /var/cache/ssu/features.ini
   ssu ur
 fi
+exit 0
 
 %postun testing
-if [ $1 = 0 ]  # Removal
+if [ "$1" = 0 ]  # Removal
   ssu rr sailfishos-chum-testing
   rm -f /var/cache/ssu/features.ini
   ssu ur
 fi
+exit 0
 
 # BTW, `ssu`, `rm -f`, `mkdir -p` etc. *always* return with "0" ("success"), hence
 # no appended `|| true` needed to satisfy `set -e` for failing commands outside of
 # flow control directives (if, while, until etc.).  Furthermore on Fedora Docs it
 # is indicated that solely the final exit status of a whole scriptlet is crucial: 
-# https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+# See https://docs.pagure.org/packaging-guidelines/Packaging%3AScriptlets.html
+# or https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_syntax
+# committed on 18 February 2019 by tibbs ( https://pagure.io/user/tibbs ) as
+# "8d0cec9 Partially convert to semantic line breaks." in
+# https://pagure.io/packaging-committee/c/8d0cec97aedc9b34658d004e3a28123f36404324

--- a/rpm/chum.spec
+++ b/rpm/chum.spec
@@ -6,6 +6,7 @@ Release:        1
 Provides:       sailfishos-chum-repository
 Group:          System
 Source0:        %{name}-%{version}.tar.bz2
+Requires(post): ssu
 Requires:       ssu
 Conflicts:      sailfishos-chum-testing
 Conflicts:      sailfishos-chum-gui
@@ -28,6 +29,7 @@ Summary:        SSU configuration for the SailfishOS:Chum TESTING repository
 License:        MIT
 Provides:       sailfishos-chum-repository
 Group:          System
+Requires(post): ssu
 Requires:       ssu
 Conflicts:      sailfishos-chum
 Conflicts:      sailfishos-chum-gui


### PR DESCRIPTION
* Use %post instead of %posttrans.  %post can be limited to either only on installation, only on upgrade or allow for both.  %posttrans cannot be limited and is very last executed before the RPM transaction finishes; it is provided for special cases, using it for generic purposes in rather unusual.

* Only add repositories, if they are not already configured.

* Cease executing `rm -f /var/cache/ssu/features.ini` when adding repositories.

* Limit removal of repositories to when %postun is run upon removal of the package (i.e., not also on upgrades).

* Omit `-n %{name}-%{version}`, because it is the default for the `%setup`macro, see: http://ftp.rpm.org/max-rpm/s1-rpm-inside-macros.html#S3-RPM-INSIDE-SETUP-N-OPTION

* Specify that `ssu` is already needed for the %post scriptlet.